### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/jsdoc/template/tmpl/properties.tmpl
+++ b/jsdoc/template/tmpl/properties.tmpl
@@ -7,7 +7,7 @@
     props.forEach(function(prop, i) {
         if (!prop) { return; }
         if ( parentProp && prop.name && prop.name.indexOf(parentProp.name + '.') === 0 ) {
-            prop.name = prop.name.substr(parentProp.name.length+1);
+            prop.name = prop.name.slice(parentProp.name.length+1);
             parentProp.subprops = parentProp.subprops || [];
             parentProp.subprops.push(prop);
             props[i] = null;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.